### PR TITLE
feat: add direct marker gene input to bypass genome extraction subworkflow

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -69,15 +69,22 @@ workflow {
     //
     validateParameters()
 
+    // Ensure at least one input source is provided
+    if (!params.input && !params.marker_genes) {
+        error "ERROR: Please provide at least one of --input (samplesheet with genomes) or --marker_genes (pre-extracted marker gene FASTAs)"
+    }
+
     //
     // Print parameter summary
     //
     log.info paramsSummaryLog(workflow)
 
     //
-    // Create input channel from samplesheet
+    // Create input channel from samplesheet (empty if only marker_genes provided)
     //
-    ch_input = channel.fromList(samplesheetToList(params.input, "assets/schema_input.json"))
+    ch_input = params.input
+        ? channel.fromList(samplesheetToList(params.input, "assets/schema_input.json"))
+        : channel.empty()
 
     //
     // WORKFLOW: Run main workflow

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,11 @@ params {
     // Input options
     input                      = null
 
+    // Direct marker gene input (bypasses genome extraction subworkflow)
+    // Provide a glob path to pre-extracted marker gene FASTA files
+    // e.g. '18S-test-data/*.fasta'
+    marker_genes               = null
+
     // Pipeline options
     organism_type              = 'eukaryotic'  // 'eukaryotic' or 'bacterial'
     itsx_organism_code         = 'G'           // ITSx organism code (G = Chlorophyta/green-algae)

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,9 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -40,6 +42,12 @@
                     "type": "string",
                     "description": "MultiQC report title. Printed as page header, used for filename if not otherwise specified.",
                     "fa_icon": "fas fa-file-signature"
+                },
+                "marker_genes": {
+                    "type": "string",
+                    "description": "Path or glob to pre-extracted marker gene FASTA files. These bypass the genome extraction subworkflow and go directly to BLAST + Mothur classification.",
+                    "help_text": "Provide a glob pattern (e.g. \"18S-test-data/*.fasta\") pointing to marker gene FASTA files. The sequence type (18S, 28S, 5_8S, ITS1, ITS2) is inferred from the filename. Can be used alone or alongside --input.",
+                    "fa_icon": "fas fa-dna"
                 }
             }
         },
@@ -48,14 +56,19 @@
             "type": "object",
             "fa_icon": "fas fa-cogs",
             "description": "Options specific to the algae taxa analysis pipeline.",
-            "required": ["organism_type"],
+            "required": [
+                "organism_type"
+            ],
             "properties": {
                 "organism_type": {
                     "type": "string",
                     "default": "eukaryotic",
                     "description": "Type of organism being analyzed (eukaryotic or bacterial).",
                     "fa_icon": "fas fa-dna",
-                    "enum": ["eukaryotic", "bacterial"],
+                    "enum": [
+                        "eukaryotic",
+                        "bacterial"
+                    ],
                     "help_text": "Determines which rRNA types to extract and which databases to use for classification. Eukaryotic organisms will analyze 18S, 28S, 5.8S, ITS1, and ITS2 sequences. Bacterial organisms will analyze 16S and 23S sequences."
                 },
                 "itsx_organism_code": {
@@ -213,7 +226,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/workflows/algae_taxa.nf
+++ b/workflows/algae_taxa.nf
@@ -20,6 +20,7 @@ include { BLAST_BLASTN as BLAST_BLASTN_OUTFMT6 } from '../modules/nf-core/blast/
 include { MOTHUR_CLASSIFY                      } from '../modules/local/mothur_classify/mothur_classify'
 include { APPEND_MOTHUR_TAXONOMY_TO_DB         } from '../modules/local/append_taxonomy_to_db/append_mothur_taxonomy_to_db'
 include { paramsSummaryLog                     } from 'plugin/nf-schema'
+include { samplesheetToList                    } from 'plugin/nf-schema'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -34,6 +35,56 @@ workflow ALGAE_TAXA {
     main:
 
     ch_versions = channel.empty()
+
+    //
+    // DIRECT MARKER GENE INPUT
+    //
+    // When params.marker_genes is provided (path or glob to pre-extracted marker
+    // gene FASTA files), these bypass the entire genome extraction subworkflow
+    // (Decompress → Barrnap → Combine GFF → Extract BED → Bedtools → Clean headers → ITSx)
+    // and feed directly into the BLAST + Mothur classification steps.
+    //
+    // The seq_type is inferred from the filename:
+    //   - Files containing "18S" → seq_type = '18S'
+    //   - Files containing "28S" → seq_type = '28S'
+    //   - Files containing "5_8S" or "5.8S" → seq_type = '5_8S'
+    //   - Files containing "ITS1" → seq_type = 'ITS1'
+    //   - Files containing "ITS2" → seq_type = 'ITS2'
+    //
+    if (params.marker_genes) {
+        ch_direct_markers = channel.fromPath(params.marker_genes, checkIfExists: true)
+            .map { fasta ->
+                def name = fasta.name
+                def sample_id = name.replaceAll(/\.(fa|fasta|fna)$/, '')
+                def seq_type = null
+
+                if (name.contains('18S') || name.contains('18s')) {
+                    seq_type = '18S'
+                }
+                else if (name.contains('28S') || name.contains('28s')) {
+                    seq_type = '28S'
+                }
+                else if (name.contains('5_8S') || name.contains('5_8s') || name.contains('5.8S') || name.contains('5.8s')) {
+                    seq_type = '5_8S'
+                }
+                else if (name.contains('ITS1') || name.contains('its1')) {
+                    seq_type = 'ITS1'
+                }
+                else if (name.contains('ITS2') || name.contains('its2')) {
+                    seq_type = 'ITS2'
+                }
+                else {
+                    // Default to 18S if no marker type detected in filename
+                    seq_type = '18S'
+                }
+
+                def meta = [id: sample_id, seq_type: seq_type]
+                [meta, fasta, seq_type]
+            }
+    }
+    else {
+        ch_direct_markers = channel.empty()
+    }
 
     //
     // MODULE: Decompress genome files if compressed
@@ -216,8 +267,10 @@ workflow ALGAE_TAXA {
             .map { meta, fasta -> [meta, fasta, 'ITS2'] }
         def ch_its_for_classification = ch_its1.mix(ch_its2)
 
-        // Combine all sequences for classification
-        def ch_all_seqs = ch_rrna_for_classification.mix(ch_its_for_classification)
+        // Combine all sequences for classification (includes direct marker genes if provided)
+        def ch_all_seqs = ch_rrna_for_classification
+            .mix(ch_its_for_classification)
+            .mix(ch_direct_markers)
 
         // Create database configurations based on sequence type
         def ch_seq_with_dbs = ch_all_seqs


### PR DESCRIPTION
## Summary

Adds a `--marker_genes` parameter that accepts pre-extracted marker gene FASTA files (e.g. from `18S-test-data/`) and routes them directly to BLAST + Mothur classification, bypassing the entire genome extraction subworkflow.

## What's bypassed

When `--marker_genes` is used, these steps are skipped for the direct marker inputs:
- `DECOMPRESS_GENOME`
- `BARRNAP_EUK` / `BARRNAP_BAC` / `BARRNAP_ARC` / `BARRNAP_MITO`
- `COMBINE_GFF`
- `EXTRACT_BED`
- `BEDTOOLS_GETFASTA`
- `CLEAN_FASTA_HEADERS`
- `ITSX`

## Sequence type inference

The marker type is inferred from the filename:
| Pattern in filename | Assigned type |
|---|---|
| `18S` or `18s` | 18S |
| `28S` or `28s` | 28S |
| `5_8S`, `5_8s`, `5.8S`, `5.8s` | 5_8S |
| `ITS1` or `its1` | ITS1 |
| `ITS2` or `its2` | ITS2 |

Falls back to `18S` if no pattern is detected.

## Usage

```bash
# Marker genes only (no genome input needed)
nextflow run main.nf \
    --marker_genes '18S-test-data/*.fasta' \
    --outdir results \
    --eukaryome_ssu_fasta /path/to/db.fasta \
    --eukaryome_ssu_taxonomy /path/to/db.tax

# Mixed: genomes + direct markers together
nextflow run main.nf \
    --input samplesheet.csv \
    --marker_genes '18S-test-data/*.fasta' \
    --outdir results
```

## Changes

- **`workflows/algae_taxa.nf`** — Added `ch_direct_markers` channel from `params.marker_genes`, mixed into `ch_all_seqs` before Mothur/BLAST
- **`nextflow.config`** — Added `marker_genes = null` parameter
- **`main.nf`** — Made `--input` optional when `--marker_genes` is provided; added validation requiring at least one
- **`nextflow_schema.json`** — Added `marker_genes` param; removed `input` from hard-required list

## Testing

Verified with `-preview` using the test data in `18S-test-data/`:
```
nextflow run main.nf --marker_genes '18S-test-data/*.fasta' --outdir results -preview
```
All BLAST + Mothur processes appear in the execution plan; genome extraction processes show no items (as expected).